### PR TITLE
Fix erroneous removal on an outer HashMap instead of it's inner ArrayList in MonitorMultipart

### DIFF
--- a/src/main/java/sonar/logistics/parts/MonitorMultipart.java
+++ b/src/main/java/sonar/logistics/parts/MonitorMultipart.java
@@ -123,7 +123,7 @@ public abstract class MonitorMultipart<T extends IMonitorInfo> extends SidedMult
 				toRemove.add(viewer);
 			}
 		}
-		toRemove.forEach(remove -> viewers.remove(remove));
+		toRemove.forEach(viewers.get(true)::remove);
 	}
 
 	public UUID getIdentity() {


### PR DESCRIPTION
Something my IDE pointed out while I was looking through the source.

In the removeViewer(EntityPlayer) method of MonitorMultipart you do 
`toRemove.forEach(remove -> viewers.remove(remove));`
but viewers is a `HashMap<Boolean, ArrayList<MonitorViewer>>` and `remove` is a `MonitorViewer`. It only makes sense to pass `Boolean` values to `viewers.remove(Object)`. I believe you intended call `remove(Object)` on the inner `ArrayList<MonitorViewer>` with key equal to `true`.

As far as I can tell, the method, while used, currently has no effect despite the error, but could cause problems down the line if it's not noticed.

I used a method reference to prevent calling `viewers.get(true)` for every single `MonitorViewer` to be removed. Which would be the case if I'd used `toRemove.forEach(remove -> viewers.get(true).remove(remove));` instead.
